### PR TITLE
Updated dependency on Android gradle plugin to 0.12.+

### DIFF
--- a/NavigationDrawerSample/build.gradle
+++ b/NavigationDrawerSample/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.11.+'
+        classpath 'com.android.tools.build:gradle:0.12.+'
     }
 }
 


### PR DESCRIPTION
In AS 0.8.1, I got an error saying the version of Android gradle plugin (0.11.+) was unsupported when I tried to open the cloned project. Editing the build.gradle and setting this manually to 0.12.+ did the trick.